### PR TITLE
Added import for piecemeal/vec.dart

### DIFF
--- a/lib/src/engine/command/archery.dart
+++ b/lib/src/engine/command/archery.dart
@@ -1,5 +1,7 @@
 library hauberk.engine.command.archery;
 
+import 'package:piecemeal/src/vec.dart';
+
 import '../action/action.dart';
 import '../action/bolt.dart';
 import '../game.dart';


### PR DESCRIPTION
`Action getTargetAction(Game game, Vec target)` in archery.dart requires the Vec class but it isn't imported. Should archery.dart have `import 'package:piecemeal/src/vec.dart'`? I get an undefined class warning from DartEditor.
