### PR TITLE
Add gems and rocks

### DIFF
--- a/lib/src/content/items.dart
+++ b/lib/src/content/items.dart
@@ -89,7 +89,7 @@ void treasure() {
   category(r"$", "treasure/rock");
   item("Turquoise Stone", 15, aqua);
   item("Onyx Stone",      20, darkGray);
-  item("Malachite Stone", 25, darkAqua);
+  item("Malachite Stone", 25, lightGreen);
   item("Jade Stone",      30, darkGreen);
   item("Pearl",           35, lightYellow);
   item("Opal",            40, lightPurple);


### PR DESCRIPTION
This is my first attempt at doing some fleshing-out of content as recommended. I tried to find if I needed to do anything to make the new categories (`treasure/gem` and `treasure/rock`) work but didn't come across anything. The levels are somewhat arbitrary but I tried to use my best RP judgment. I couldn't find `Color.CYAN` so I looked up the RGB value of cyan to see if I could add it myself. Google tells me it's rgb(0, 255, 255) which is already listed under Color.AQUA so I just went with that for Turquoise Stone. Also, I noticed Malachite Stone was commented as dark cyan but looked it up and I think it should be light green? (http://en.wikipedia.org/wiki/Malachite under Color on the right)
