### PR TITLE
Slightly nicer messages on death

### DIFF
--- a/lib/src/engine/actor.dart
+++ b/lib/src/engine/actor.dart
@@ -161,10 +161,11 @@ abstract class Actor extends Thing {
     if (health.current > 0) return false;
 
     action.addEvent(EventType.DIE, actor: this);
-    onDied(attacker);
 
     action.log("{1} kill[s] {2}.", attackNoun, this);
     if (attacker != null) attacker.onKilled(action, this);
+
+    onDied(attacker);
 
     return true;
   }

--- a/lib/src/engine/hero/hero.dart
+++ b/lib/src/engine/hero/hero.dart
@@ -184,6 +184,10 @@ class Hero extends Actor {
     heroClass.killedMonster(action, defender);
   }
 
+  void onDied(Actor attacker) {
+    game.log.message("you were slain by {1}.", attacker);
+  }
+
   void onFinishTurn(Action action) {
     // Make some noise.
     _lastNoise = action.noise;

--- a/lib/src/ui/game_over_screen.dart
+++ b/lib/src/ui/game_over_screen.dart
@@ -5,7 +5,9 @@ import 'package:malison/malison.dart';
 import 'input.dart';
 
 class GameOverScreen extends Screen {
-  GameOverScreen();
+  final Log log;
+
+  GameOverScreen(this.log);
 
   bool handleInput(Input input) {
     switch (input) {
@@ -20,8 +22,7 @@ class GameOverScreen extends Screen {
   void render(Terminal terminal) {
     terminal.clear();
 
-    // TODO: Show more here. Explain what happens to your character.
-    terminal.writeAt(0, 0, 'You have died.');
+    terminal.writeAt(0, 0, log.messages.last.text);
     terminal.writeAt(0, terminal.height - 1,
         '[Esc] Return to quest menu',
         Color.GRAY);

--- a/lib/src/ui/game_screen.dart
+++ b/lib/src/ui/game_screen.dart
@@ -252,7 +252,7 @@ class GameScreen extends Screen {
 
     // See if the hero died.
     if (!game.hero.isAlive) {
-      ui.goTo(new GameOverScreen());
+      ui.goTo(new GameOverScreen(game.log));
       return;
     }
 


### PR DESCRIPTION
The game over screen now shows the name of the monster that killed you. Currently looks something like:

```
You were slain by the simpering knave.
```

I thought it would be nice if the death screen was presented in the past tense (in contrast to the rest of the log messages, which are in present tense).

I put this into the log, as it seemed a bit overkill to introduce a special `HeroStone` or `Epitaph` object at this stage, but I did go down a bit of a rabbit hole looking for ways to describe the death in more detail based on the action/attack verb. See below...
### Notes and thoughts:
- Unsure whether it matters if a monster’s death is logged before the monster’s drops are logged, or after.
- One tricky thing is that the verbs associated with attacks aren’t set up to be accessed atomically. Pulling the string out of the context where `onDied` is called would require more code changes than I thought at first.
- It might be silly/annoying to have to go through the entire list of monsters/items and add past tense variations of attack verbs just to open up creative possibilities for the death screen.
- For improved texture/tone, insects and small creatures could use the verb **killed**; people, goblins, humanoids, etc could use the verb **slain**.
- What happens when the hero dies of an effect (cold, fire, poison)? In these cases, the message should be something like: `[Hero] succumbed to the effects of [monster] [material].`

_eg:_

```
You were killed by slug poison.
You succumbed to the effects of the slug’s poison.
```

_(Sentences with the possessive apostrophe would require additional messing about with formatting code to generalize)_
- An alternative way to handle this would be to forget about the idea of converting verbs to past-tense from the in-game actions and instead, procedurally generate a unique sentence based on the hero’s class and XP, the number of turns they survived in that level, and similar info at the point of death.

_eg:_

```
You were unceremoniously slain by the simpering knave. What a waste.
You bleed slowly to death on the dungeon floor.
Your plea for death is answered. The goblin peon is victorious.
```

_or:_

```
 ________________________________
/                                \
|             R.I.P              |
|                                |
|       Here lies [Hero]         |
|          The [Class]           |
|        Who fought [Adj]        |
|  Against the [Adj][Monsters]   |
|        Of the [Level]          |
|                                |
|                                |
|________________________________|
```

See also: 
- https://github.com/TheBerkin/Rant
- http://en.wikipedia.org/wiki/Hero_stone
