### PR TITLE
Add dialog for picking up multiple items at a location

### DIFF
--- a/lib/src/engine/action/item.dart
+++ b/lib/src/engine/action/item.dart
@@ -56,9 +56,12 @@ abstract class ItemAction extends Action {
 
 /// [Action] for picking up an [Item] off the ground.
 class PickUpAction extends Action {
+  final int index;
+
+  PickUpAction(this.index);
+
   ActionResult onPerform() {
-    // TODO: Handle stacks on the ground.
-    var item = game.stage.itemAt(actor.pos);
+    var item = game.stage.itemsAt(actor.pos)[index];
     if (item == null) return fail('There is nothing here.');
 
     if (!hero.inventory.tryAdd(item)) {

--- a/lib/src/ui/game_screen.dart
+++ b/lib/src/ui/game_screen.dart
@@ -86,7 +86,7 @@ class GameScreen extends Screen {
         break;
 
       case Input.CLOSE_DOOR: closeDoor(); break;
-      case Input.PICK_UP: action = new PickUpAction(); break;
+      case Input.PICK_UP: pickUp(); break;
 
       case Input.NW: action = new WalkAction(Direction.NW); break;
       case Input.N: action = new WalkAction(Direction.N); break;
@@ -172,6 +172,18 @@ class GameScreen extends Screen {
       game.hero.setNextAction(new CloseDoorAction(doors[0]));
     } else {
       ui.push(new CloseDoorDialog(game));
+    }
+  }
+
+  void pickUp() {
+    final items = game.stage.itemsAt(game.hero.pos);
+
+    if (items.length > 1) {
+      // Show item dialog if there are multiple things to pick up.
+      ui.push(new ItemDialog.pickUp(this));
+    } else {
+      // Otherwise attempt to pick up any available item.
+      game.hero.setNextAction(new PickUpAction(items.length - 1));
     }
   }
 


### PR DESCRIPTION
Uses the existing `ItemDialog` rather than creating a new UI class.

A few small things that could be improved here, like encapsulating the `itemsAt(pos)[index]` access and dealing with a full inventory before popping up the dialog. It’s just the bare minimum changeset for now.